### PR TITLE
TASK-83 Report external file integration

### DIFF
--- a/core/src/main/kotlin/ru/surf/core/configuration/HessianConfiguration.kt
+++ b/core/src/main/kotlin/ru/surf/core/configuration/HessianConfiguration.kt
@@ -4,7 +4,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import ru.surf.auth.service.CredentialsService
-import ru.surf.externalfiles.service.ResourceFileService
+import ru.surf.externalfiles.service.S3FacadeService
 import ru.surf.externalfiles.service.S3FileService
 import ru.surf.remoting.hessian.accessor.HessianProxyFactoryBean
 
@@ -16,6 +16,9 @@ class HessianConfiguration(
 
         @Value("\${externalFiles.s3FileServiceApi}")
         private val s3FileServiceApi: String,
+
+        @Value("\${externalFiles.s3FacadeServiceApi}")
+        private val s3FacadeServiceApi: String,
 
         @Value("\${externalFiles.s3ResourceServiceApi}")
         private val s3ResourceServiceApi: String
@@ -32,6 +35,12 @@ class HessianConfiguration(
     fun s3FileServiceHessianInvoker(): HessianProxyFactoryBean<S3FileService> = HessianProxyFactoryBean(
             serviceInterface = S3FileService::class.java,
             serviceUrl = s3FileServiceApi
+    )
+
+    @Bean(name = ["s3FacadeServiceApiHessianInvoker"])
+    fun s3FacadeServiceHessianInvoker(): HessianProxyFactoryBean<S3FacadeService> = HessianProxyFactoryBean(
+        serviceInterface = S3FacadeService::class.java,
+        serviceUrl = s3FacadeServiceApi
     )
 
     // TODO: 25.02.2023 Нужна помощь

--- a/core/src/main/kotlin/ru/surf/core/controller/EventController.kt
+++ b/core/src/main/kotlin/ru/surf/core/controller/EventController.kt
@@ -1,12 +1,10 @@
 package ru.surf.core.controller
 
-import aj.org.objectweb.asm.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.*
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.client.RestTemplate
-import org.springframework.web.client.exchange
 import org.springframework.web.util.UriComponentsBuilder
 import ru.surf.core.dto.FullResponseEventDto
 import ru.surf.core.dto.PostRequestEventDto
@@ -76,4 +74,12 @@ class EventController(
         candidateService.notifyCandidates(forEntity.body!!)
     }
 
+    @GetMapping("/{id}/report")
+    fun getReport(@PathVariable(name = "id") eventId: UUID): ResponseEntity<ByteArray> {
+        val target = eventService.getReport(eventId)
+
+        return ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_PDF)
+            .body(target)
+    }
 }

--- a/core/src/main/kotlin/ru/surf/core/controller/GlobalExceptionHandler.kt
+++ b/core/src/main/kotlin/ru/surf/core/controller/GlobalExceptionHandler.kt
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import ru.surf.core.dto.ErrorDto
 import ru.surf.core.exception.event.EventNotFoundByIdException
+import ru.surf.core.exception.event.EventReportNotFoundException
 import java.time.LocalDateTime
 
 
@@ -18,4 +19,9 @@ class GlobalExceptionHandler {
         return ResponseEntity(errorDto, HttpStatus.NOT_FOUND)
     }
 
+    @ExceptionHandler(EventReportNotFoundException::class)
+    fun handleEventReportNotFoundException(exception: EventReportNotFoundException): ResponseEntity<ErrorDto> {
+        val errorDto = ErrorDto(exception.exceptionType.toString(), exception.message, LocalDateTime.now())
+        return ResponseEntity(errorDto, HttpStatus.NOT_FOUND)
+    }
 }

--- a/core/src/main/kotlin/ru/surf/core/exception/event/EventReportNotFoundException.kt
+++ b/core/src/main/kotlin/ru/surf/core/exception/event/EventReportNotFoundException.kt
@@ -1,0 +1,16 @@
+package ru.surf.core.exception.event
+
+import ru.surf.core.exception.ExceptionType
+import ru.surf.core.exception.base.CoreServiceException
+import java.util.*
+
+class EventReportNotFoundException(val id: UUID) : CoreServiceException() {
+
+    val exceptionType = ExceptionType.SERVICE_EXCEPTION
+
+    override val message: String
+        get() = description
+
+    public override val description: String = "NO REPORT FOR EVENT WITH ID $id"
+
+}

--- a/core/src/main/kotlin/ru/surf/core/repository/EventRepository.kt
+++ b/core/src/main/kotlin/ru/surf/core/repository/EventRepository.kt
@@ -1,6 +1,7 @@
 package ru.surf.core.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import ru.surf.core.entity.Event
 import ru.surf.core.entity.EventTag
@@ -10,5 +11,8 @@ import java.util.*
 interface EventRepository : JpaRepository<Event, UUID> {
 
     fun findByEventTagsIn(eventTags: Set<EventTag>): Event?
+
+    @Query("select e.reportFileId from Event e where e.id = :eventId")
+    fun getReportFileId(eventId: UUID): UUID?
 
 }

--- a/core/src/main/kotlin/ru/surf/core/service/EventService.kt
+++ b/core/src/main/kotlin/ru/surf/core/service/EventService.kt
@@ -16,4 +16,6 @@ interface EventService {
 
     fun updateEvent(id: UUID, putRequestEventDto: PutRequestEventDto): ShortResponseEventDto
 
+    fun getReport(id: UUID): ByteArray
+
 }

--- a/core/src/main/kotlin/ru/surf/core/service/impl/EventServiceImpl.kt
+++ b/core/src/main/kotlin/ru/surf/core/service/impl/EventServiceImpl.kt
@@ -8,10 +8,12 @@ import ru.surf.core.dto.ShortResponseEventDto
 import ru.surf.core.entity.Event
 import ru.surf.core.entity.EventState
 import ru.surf.core.exception.event.EventNotFoundByIdException
+import ru.surf.core.exception.event.EventReportNotFoundException
 import ru.surf.core.mapper.event.EventMapper
 import ru.surf.core.repository.EventRepository
 import ru.surf.core.service.EventService
 import ru.surf.core.service.SurfEmployeeService
+import ru.surf.externalfiles.service.S3FacadeService
 import java.time.ZonedDateTime
 import java.util.*
 
@@ -21,6 +23,7 @@ class EventServiceImpl(
     private val eventMapper: EventMapper,
     private val eventRepository: EventRepository,
     private val surfEmployeeService: SurfEmployeeService,
+    private val s3FacadeService: S3FacadeService
 ) : EventService {
 
     override fun createEvent(postRequestEventDto: PostRequestEventDto): ShortResponseEventDto {
@@ -60,6 +63,12 @@ class EventServiceImpl(
         }
         val persistedEvent = eventRepository.save(eventFromDb)
         return eventMapper.convertFromEventEntityToShortResponseEventDto(persistedEvent)
+    }
+
+    override fun getReport(id: UUID): ByteArray {
+        val reportFileId = eventRepository.getReportFileId(id) ?: throw EventReportNotFoundException(id)
+
+        return s3FacadeService.getFile(reportFileId)
     }
 
     override fun deleteEvent(id: UUID) {

--- a/core/src/main/resources/db/migration/core/V1.1.2__adding_report_id_to event.sql
+++ b/core/src/main/resources/db/migration/core/V1.1.2__adding_report_id_to event.sql
@@ -1,3 +1,4 @@
 alter table events
     add column if not exists
-        report_file_id uuid default null;
+        report_file_id uuid
+            constraint events_s3files_report_file_id_fk references s3files (id) on delete set null default null;

--- a/core/src/main/resources/db/migration/core/V1.1.2__adding_report_id_to event.sql
+++ b/core/src/main/resources/db/migration/core/V1.1.2__adding_report_id_to event.sql
@@ -1,0 +1,3 @@
+alter table events
+    add column if not exists
+        report_file_id uuid default null;

--- a/domain/src/main/kotlin/ru/surf/core/entity/Event.kt
+++ b/domain/src/main/kotlin/ru/surf/core/entity/Event.kt
@@ -45,6 +45,9 @@ class Event(
         @JoinColumn(name = "event_id")
         var eventStates: Set<EventState> = mutableSetOf(),
 
+        @Column(name = "report_file_id", nullable = true)
+        var reportFileId: UUID? = UUID.randomUUID()
+
         ) : UUIDBasedEntity(id) {
 
     val currentState: EventState?

--- a/domain/src/main/kotlin/ru/surf/core/kafkaEvents/EndingEvent.kt
+++ b/domain/src/main/kotlin/ru/surf/core/kafkaEvents/EndingEvent.kt
@@ -1,0 +1,7 @@
+package ru.surf.core.kafkaEvents
+
+import java.util.UUID
+
+data class EndingEvent(
+    val eventId: UUID
+)

--- a/external-files/src/main/kotlin/ru/surf/externalfiles/configuration/HessianConfiguration.kt
+++ b/external-files/src/main/kotlin/ru/surf/externalfiles/configuration/HessianConfiguration.kt
@@ -3,6 +3,7 @@ package ru.surf.externalfiles.configuration
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import ru.surf.externalfiles.service.S3FacadeService
 import ru.surf.externalfiles.service.S3FileService
 import ru.surf.remoting.RemoteExporter
 import ru.surf.remoting.hessian.exporter.HessianHttpServiceExporter
@@ -17,6 +18,13 @@ class HessianConfiguration {
                     service = s3FileService,
                     serviceInterface = S3FileService::class.java
             )
+
+    @Bean(name = ["/s3FacadeServiceApi"])
+    fun hessianS3FacadeService(@Autowired s3FacadeService: S3FacadeService): RemoteExporter<S3FacadeService> =
+        HessianHttpServiceExporter(
+            service = s3FacadeService,
+            serviceInterface = S3FacadeService::class.java
+        )
 
    /* @Bean(name = ["/s3ResourceFileServiceApi"])
     fun hessianS3ResourceFileService(resourceFileService: ResourceFileService): RemoteExporter {

--- a/external-files/src/main/kotlin/ru/surf/externalfiles/controller/S3FileController.kt
+++ b/external-files/src/main/kotlin/ru/surf/externalfiles/controller/S3FileController.kt
@@ -1,12 +1,10 @@
 package ru.surf.externalfiles.controller
 
-import org.springframework.core.io.ByteArrayResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import ru.surf.externalfiles.dto.PostResponseDto
 import ru.surf.externalfiles.service.S3FacadeService
-import ru.surf.externalfiles.service.S3FileService
 import java.util.UUID
 
 //TODO: реализовать привязку файла к пользователю
@@ -20,8 +18,9 @@ class S3FileController(private val s3FacadeService: S3FacadeService) {
     fun uploadFile(@RequestParam(name = "file") multipartFile: MultipartFile): ResponseEntity<PostResponseDto> =
         ResponseEntity.ok(s3FacadeService.saveFile(multipartFile))
 
+//    TODO: Сделать автоматическую загрузку файла при вызове эндпоинта
     @GetMapping("/{id}")
-    fun downloadFile(@PathVariable(name = "id") id: UUID): ResponseEntity<ByteArrayResource> {
+    fun downloadFile(@PathVariable(name = "id") id: UUID): ResponseEntity<ByteArray> {
         return ResponseEntity.ok(s3FacadeService.getFile(id))
     }
 

--- a/external-files/src/main/kotlin/ru/surf/externalfiles/service/S3FacadeService.kt
+++ b/external-files/src/main/kotlin/ru/surf/externalfiles/service/S3FacadeService.kt
@@ -1,6 +1,5 @@
 package ru.surf.externalfiles.service
 
-import org.springframework.core.io.ByteArrayResource
 import org.springframework.web.multipart.MultipartFile
 import ru.surf.externalfiles.dto.PostResponseDto
 import java.util.UUID
@@ -9,7 +8,7 @@ interface S3FacadeService {
 
     fun saveFile(file: MultipartFile): PostResponseDto
 
-    fun getFile(fileId: UUID): ByteArrayResource
+    fun getFile(fileId: UUID): ByteArray
 
     fun deleteFile(fileId: UUID)
 

--- a/external-files/src/main/kotlin/ru/surf/externalfiles/service/impl/ResourceFileServiceImpl.kt
+++ b/external-files/src/main/kotlin/ru/surf/externalfiles/service/impl/ResourceFileServiceImpl.kt
@@ -18,7 +18,7 @@ class ResourceFileServiceImpl(
 
     override fun parseHrExcelFile(fileId: UUID): List<CandidateExcelDto> {
         val excelFile = s3FacadeService.getFile(fileId)
-        val sheet: XSSFSheet = XSSFWorkbook(ByteArrayInputStream(excelFile.byteArray)).getSheet("Кандидаты")
+        val sheet: XSSFSheet = XSSFWorkbook(ByteArrayInputStream(excelFile)).getSheet("Кандидаты")
         return (1..sheet.lastRowNum).map { sheet.getRow(it) }.map {
             CandidateExcelDto(
                 firstName = it.getCell(0).stringCellValue,

--- a/report/build.gradle.kts
+++ b/report/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 	runtimeOnly("org.jetbrains.kotlinx:kotlinx-coroutines-reactive")
-
+	implementation("org.springframework.kafka:spring-kafka")
 
 	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/report/src/main/kotlin/ru/surf/report/config/KafkaConfig.kt
+++ b/report/src/main/kotlin/ru/surf/report/config/KafkaConfig.kt
@@ -1,4 +1,4 @@
-package ru.surf.mail.configuration
+package ru.surf.report.config
 
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -15,10 +15,9 @@ import org.springframework.kafka.support.converter.JsonMessageConverter
 import org.springframework.kafka.support.serializer.JsonDeserializer
 import org.springframework.util.backoff.FixedBackOff
 
-
 @Configuration
 @EnableKafka
-class KafkaConfiguration(
+class KafkaConfig(
     @Value("\${spring.kafka.bootstrap-servers}")
     private val bootstrapServers: String
 ) {
@@ -33,8 +32,8 @@ class KafkaConfiguration(
         return DefaultKafkaConsumerFactory(
             mapOf(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG to bootstrapServers,
-                ConsumerConfig.CLIENT_ID_CONFIG to "mail_service",
-                ConsumerConfig.GROUP_ID_CONFIG to "2",
+                ConsumerConfig.CLIENT_ID_CONFIG to "report_service",
+                ConsumerConfig.GROUP_ID_CONFIG to "3",
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG to "StringDeserializer::class.java",
                 ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG to "JsonDeserializer::class.java",
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG to "earliest"

--- a/report/src/main/kotlin/ru/surf/report/config/ReportModuleConfig.kt
+++ b/report/src/main/kotlin/ru/surf/report/config/ReportModuleConfig.kt
@@ -10,8 +10,6 @@ import org.springframework.web.reactive.function.client.WebClient
 @Configuration
 @EntityScan("ru.surf.core.entity")
 class ReportModuleConfig(
-    @Value("\${services.testing.url}")
-    private val testingServiceUrl: String,
     @Value("\${services.report.base_url}")
     private val baseUrl: String
 ) {
@@ -25,7 +23,6 @@ class ReportModuleConfig(
     @Bean
     fun restTemplate(): WebClient {
         return WebClient.builder()
-            .baseUrl(testingServiceUrl)
             .build()
     }
 }

--- a/report/src/main/kotlin/ru/surf/report/controller/ReportController.kt
+++ b/report/src/main/kotlin/ru/surf/report/controller/ReportController.kt
@@ -2,37 +2,32 @@ package ru.surf.report.controller
 
 import com.itextpdf.html2pdf.ConverterProperties
 import com.itextpdf.html2pdf.HtmlConverter
-import jakarta.servlet.http.HttpServletRequest
-import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
-import org.thymeleaf.context.WebContext
+import org.thymeleaf.context.Context
 import org.thymeleaf.spring6.SpringTemplateEngine
-import org.thymeleaf.web.servlet.JakartaServletWebApplication
 import ru.surf.report.service.ReportService
 import java.io.ByteArrayOutputStream
 import java.util.*
 
 
 @Controller
-@RequestMapping(value = ["/report"])
+@RequestMapping(value = ["/final_report"])
 class ReportController(
     private val templateEngine: SpringTemplateEngine,
-    private val request: HttpServletRequest,
-    private val response: HttpServletResponse,
     private val reportService: ReportService,
-    private val converterProperties: ConverterProperties
+    private val converterProperties: ConverterProperties,
 ) {
 
     @GetMapping("/pdf/{event_id}")
     fun getPdf(@PathVariable(name = "event_id") eventId: UUID): ResponseEntity<ByteArray> {
-        val context = webContext()
+        val context = Context()
 
-        context.setVariable("report", reportService.getPdfReport(eventId))
+        context.setVariable("report", reportService.getReport(eventId))
         val html = templateEngine.process("report", context)
 
         val target = ByteArrayOutputStream()
@@ -41,11 +36,5 @@ class ReportController(
         return ResponseEntity.ok()
             .contentType(MediaType.APPLICATION_PDF)
             .body(target.toByteArray())
-    }
-
-    fun webContext(): WebContext {
-        val application = JakartaServletWebApplication.buildApplication(request.servletContext)
-        val exchange = application.buildExchange(request, response)
-        return WebContext(exchange)
     }
 }

--- a/report/src/main/kotlin/ru/surf/report/controller/ReportController.kt
+++ b/report/src/main/kotlin/ru/surf/report/controller/ReportController.kt
@@ -1,40 +1,31 @@
 package ru.surf.report.controller
 
-import com.itextpdf.html2pdf.ConverterProperties
-import com.itextpdf.html2pdf.HtmlConverter
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
-import org.thymeleaf.context.Context
-import org.thymeleaf.spring6.SpringTemplateEngine
 import ru.surf.report.service.ReportService
-import java.io.ByteArrayOutputStream
+import ru.surf.report.service.ReportWrapper
 import java.util.*
 
 
 @Controller
 @RequestMapping(value = ["/final_report"])
 class ReportController(
-    private val templateEngine: SpringTemplateEngine,
     private val reportService: ReportService,
-    private val converterProperties: ConverterProperties,
+    private val reportWrapper: ReportWrapper
 ) {
 
     @GetMapping("/pdf/{event_id}")
     fun getPdf(@PathVariable(name = "event_id") eventId: UUID): ResponseEntity<ByteArray> {
-        val context = Context()
-
-        context.setVariable("report", reportService.getReport(eventId))
-        val html = templateEngine.process("report", context)
-
-        val target = ByteArrayOutputStream()
-        HtmlConverter.convertToPdf(html, target, converterProperties)
+        val report = reportWrapper.wrap(
+            reportService.getReport(eventId)
+        )
 
         return ResponseEntity.ok()
             .contentType(MediaType.APPLICATION_PDF)
-            .body(target.toByteArray())
+            .body(report)
     }
 }

--- a/report/src/main/kotlin/ru/surf/report/controller/ReportListener.kt
+++ b/report/src/main/kotlin/ru/surf/report/controller/ReportListener.kt
@@ -1,39 +1,30 @@
 package ru.surf.report.controller
 
-import com.itextpdf.html2pdf.ConverterProperties
-import com.itextpdf.html2pdf.HtmlConverter
 import org.springframework.kafka.annotation.KafkaHandler
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.annotation.RetryableTopic
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
-import org.thymeleaf.context.Context
-import org.thymeleaf.spring6.SpringTemplateEngine
 import ru.surf.core.kafkaEvents.EndingEvent
 import ru.surf.report.service.ReportService
-import java.io.ByteArrayOutputStream
+import ru.surf.report.service.ReportWrapper
 
 
 @Component
 @KafkaListener(topics = ["core-topics"])
 class ReportListener(
-    private val templateEngine: SpringTemplateEngine,
     private val reportService: ReportService,
-    private val converterProperties: ConverterProperties,
+    private val reportWrapper: ReportWrapper
 ) {
 
     @KafkaHandler
     @RetryableTopic
     fun onEndingEvent(@Payload value: EndingEvent) {
-        val context = Context()
+        val report = reportWrapper.wrap(
+            reportService.getReport(value.eventId)
+        )
 
-        context.setVariable("report", reportService.getReport(value.eventId))
-        val html = templateEngine.process("report", context)
-
-        val target = ByteArrayOutputStream()
-        HtmlConverter.convertToPdf(html, target, converterProperties)
-
-        reportService.saveReport(target.toByteArray(), value.eventId)
+        reportService.saveReport(report, value.eventId)
     }
 
     @KafkaHandler(isDefault = true)

--- a/report/src/main/kotlin/ru/surf/report/controller/ReportListener.kt
+++ b/report/src/main/kotlin/ru/surf/report/controller/ReportListener.kt
@@ -1,0 +1,41 @@
+package ru.surf.report.controller
+
+import com.itextpdf.html2pdf.ConverterProperties
+import com.itextpdf.html2pdf.HtmlConverter
+import org.springframework.kafka.annotation.KafkaHandler
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.annotation.RetryableTopic
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.stereotype.Component
+import org.thymeleaf.context.Context
+import org.thymeleaf.spring6.SpringTemplateEngine
+import ru.surf.core.kafkaEvents.EndingEvent
+import ru.surf.report.service.ReportService
+import java.io.ByteArrayOutputStream
+
+
+@Component
+@KafkaListener(topics = ["core-topics"])
+class ReportListener(
+    private val templateEngine: SpringTemplateEngine,
+    private val reportService: ReportService,
+    private val converterProperties: ConverterProperties,
+) {
+
+    @KafkaHandler
+    @RetryableTopic
+    fun onEndingEvent(@Payload value: EndingEvent) {
+        val context = Context()
+
+        context.setVariable("report", reportService.getReport(value.eventId))
+        val html = templateEngine.process("report", context)
+
+        val target = ByteArrayOutputStream()
+        HtmlConverter.convertToPdf(html, target, converterProperties)
+
+        reportService.saveReport(target.toByteArray(), value.eventId)
+    }
+
+    @KafkaHandler(isDefault = true)
+    fun default() = Unit
+}

--- a/report/src/main/kotlin/ru/surf/report/model/PostResponseDto.kt
+++ b/report/src/main/kotlin/ru/surf/report/model/PostResponseDto.kt
@@ -1,0 +1,10 @@
+package ru.surf.report.model
+
+import java.util.UUID
+
+
+data class PostResponseDto(
+    val fileId: UUID,
+    val name: String,
+    val size: Long,
+)

--- a/report/src/main/kotlin/ru/surf/report/repository/CandidateRepository.kt
+++ b/report/src/main/kotlin/ru/surf/report/repository/CandidateRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param
 import ru.surf.core.entity.Candidate
 import java.util.UUID
 
+
 interface CandidateRepository : JpaRepository<Candidate, UUID> {
     @Query("select count(c) from Candidate c where c.event.id = :eventId")
     fun countByEventId(@Param("eventId") eventId: UUID): Int

--- a/report/src/main/kotlin/ru/surf/report/repository/EventRepository.kt
+++ b/report/src/main/kotlin/ru/surf/report/repository/EventRepository.kt
@@ -16,7 +16,7 @@ interface EventRepository : JpaRepository<Event, UUID> {
     @Query("select e.eventStates from Event e where e.id = :eventId")
     fun getStatesById(@Param("eventId") eventId: UUID): Set<EventState>
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("update events set report_file_id = :reportFileId where id = :eventId", nativeQuery = true)
     fun updateReportFileId(@Param("reportFileId") reportFileId: UUID, @Param("eventId") eventId: UUID)
 }

--- a/report/src/main/kotlin/ru/surf/report/repository/EventRepository.kt
+++ b/report/src/main/kotlin/ru/surf/report/repository/EventRepository.kt
@@ -1,11 +1,13 @@
 package ru.surf.report.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import ru.surf.core.entity.Event
 import ru.surf.core.entity.EventState
-import java.util.UUID
+import java.util.*
+
 
 interface EventRepository : JpaRepository<Event, UUID> {
     @Query("select e.description from Event e where e.id = :eventId")
@@ -13,4 +15,8 @@ interface EventRepository : JpaRepository<Event, UUID> {
 
     @Query("select e.eventStates from Event e where e.id = :eventId")
     fun getStatesById(@Param("eventId") eventId: UUID): Set<EventState>
+
+    @Modifying
+    @Query("update events set report_file_id = :reportFileId where id = :eventId", nativeQuery = true)
+    fun updateReportFileId(@Param("reportFileId") reportFileId: UUID, @Param("eventId") eventId: UUID)
 }

--- a/report/src/main/kotlin/ru/surf/report/service/ReportService.kt
+++ b/report/src/main/kotlin/ru/surf/report/service/ReportService.kt
@@ -4,5 +4,6 @@ import ru.surf.report.model.Report
 import java.util.UUID
 
 interface ReportService {
-    fun getPdfReport(eventId: UUID) : Report
+    fun getReport(eventId: UUID): Report
+    fun saveReport(reportByteArray: ByteArray, eventId: UUID)
 }

--- a/report/src/main/kotlin/ru/surf/report/service/ReportServiceImpl.kt
+++ b/report/src/main/kotlin/ru/surf/report/service/ReportServiceImpl.kt
@@ -1,9 +1,16 @@
 package ru.surf.report.service
 
 import kotlinx.coroutines.runBlocking
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.http.MediaType
+import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.awaitBody
+import ru.surf.report.model.PostResponseDto
 import ru.surf.report.model.Report
 import ru.surf.report.repository.*
 import ru.surf.testing.sharedDto.CandidateScoresResponseDto
@@ -16,10 +23,15 @@ class ReportServiceImpl(
     private val candidateRepository: CandidateRepository,
     private val traineeRepository: TraineeRepository,
     private val webClient: WebClient,
+
+    @Value("\${services.testing.url}")
+    private val testingServiceUrl: String,
+    @Value("\${services.external-files.url}")
+    private val externalFilesServiceUrl: String,
 ) : ReportService {
     private lateinit var testResults: CandidateScoresResponseDto
 
-    override fun getPdfReport(eventId: UUID): Report {
+    override fun getReport(eventId: UUID): Report {
         val report = Report()
 
         getTestResult(eventId)
@@ -33,10 +45,29 @@ class ReportServiceImpl(
         return report
     }
 
+    @Transactional
+    override fun saveReport(reportByteArray: ByteArray, eventId: UUID) {
+        val builder = MultipartBodyBuilder()
+        builder.part("file", ByteArrayResource(reportByteArray))
+            .filename("Report.pdf")
+            .contentType(MediaType.APPLICATION_PDF)
+
+        val response: PostResponseDto = runBlocking {
+            webClient.post()
+                .uri("${externalFilesServiceUrl}/files/file")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(builder.build()))
+                .retrieve()
+                .awaitBody()
+        }
+
+        eventRepository.updateReportFileId(response.fileId, eventId)
+    }
+
     private fun getTestResult(eventId: UUID) {
         testResults = runBlocking {
             webClient.get()
-                .uri("/test_variant/scores/{eventId}", eventId)
+                .uri("${testingServiceUrl}/test_variant/scores/{eventId}", eventId)
                 .retrieve()
                 .awaitBody()
         }

--- a/report/src/main/kotlin/ru/surf/report/service/ReportWrapper.kt
+++ b/report/src/main/kotlin/ru/surf/report/service/ReportWrapper.kt
@@ -1,0 +1,7 @@
+package ru.surf.report.service
+
+import ru.surf.report.model.Report
+
+interface ReportWrapper {
+    fun wrap(report: Report): ByteArray
+}

--- a/report/src/main/kotlin/ru/surf/report/service/impl/ReportServiceImpl.kt
+++ b/report/src/main/kotlin/ru/surf/report/service/impl/ReportServiceImpl.kt
@@ -1,4 +1,4 @@
-package ru.surf.report.service
+package ru.surf.report.service.impl
 
 import kotlinx.coroutines.runBlocking
 import org.springframework.beans.factory.annotation.Value
@@ -13,6 +13,7 @@ import org.springframework.web.reactive.function.client.awaitBody
 import ru.surf.report.model.PostResponseDto
 import ru.surf.report.model.Report
 import ru.surf.report.repository.*
+import ru.surf.report.service.ReportService
 import ru.surf.testing.sharedDto.CandidateScoresResponseDto
 import java.util.*
 

--- a/report/src/main/kotlin/ru/surf/report/service/impl/ReportWrapperImpl.kt
+++ b/report/src/main/kotlin/ru/surf/report/service/impl/ReportWrapperImpl.kt
@@ -1,0 +1,30 @@
+package ru.surf.report.service.impl
+
+import com.itextpdf.html2pdf.ConverterProperties
+import com.itextpdf.html2pdf.HtmlConverter
+import org.springframework.stereotype.Service
+import org.thymeleaf.context.Context
+import org.thymeleaf.spring6.SpringTemplateEngine
+import ru.surf.report.model.Report
+import ru.surf.report.service.ReportWrapper
+import java.io.ByteArrayOutputStream
+
+
+@Service
+class ReportWrapperImpl(
+    private val templateEngine: SpringTemplateEngine,
+    private val converterProperties: ConverterProperties
+) : ReportWrapper {
+
+    override fun wrap(report: Report): ByteArray {
+        val context = Context()
+
+        context.setVariable("report", report)
+        val html = templateEngine.process("report", context)
+
+        val target = ByteArrayOutputStream()
+        HtmlConverter.convertToPdf(html, target, converterProperties)
+
+        return target.toByteArray()
+    }
+}

--- a/report/src/main/resources/application.yml
+++ b/report/src/main/resources/application.yml
@@ -2,6 +2,8 @@ server:
   port: 8082
 
 spring:
+  kafka:
+    bootstrap-servers: localhost:9092
   datasource:
     url: jdbc:postgresql://localhost:5432/surf_db
     username: sas
@@ -23,3 +25,5 @@ services:
     base_url: http://localhost:8082
   testing:
     url: http://0.0.0.0:8084/testing
+  external-files:
+    url: http://0.0.0.0:8181/external-files

--- a/report/src/main/resources/templates/report.html
+++ b/report/src/main/resources/templates/report.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
           name="viewport">
-    <link th:href="@{/styles.css}" rel="stylesheet"/>
+    <link href="/styles.css" rel="stylesheet"/>
     <meta content="ie=edge" http-equiv="X-UA-Compatible">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Есть EndingEvent (пока как заглушка). Если его отправить в кафку, сообщение прочитается в модуле report, там по eventId сгенерируется отчет и через webClient сохранится в external-files. Из ответа от external-files возьмется id файла и сохранится в таблице events (поле report_file_id). Получить отчет в pdf формате можно из EventController-а по eventId. 

Моментики:
В external-files надо пофиксить удаление через claim-interval
В core еще нет кода, который отвечает за отправку EndingEvent